### PR TITLE
Imperial home keywords

### DIFF
--- a/frontend/components/home/getHomepageCounts.test.ts
+++ b/frontend/components/home/getHomepageCounts.test.ts
@@ -46,6 +46,7 @@ it('returns null values on error', async () => {
     project_cnt: null,
     organisation_cnt: null,
     contributor_cnt: null,
-    software_mention_cnt: null
+    software_mention_cnt: null,
+    open_software_cnt: null,
   })
 })

--- a/frontend/components/home/imperial/KeywordBox.tsx
+++ b/frontend/components/home/imperial/KeywordBox.tsx
@@ -1,13 +1,13 @@
 import Link from 'next/link'
 
-import { ssrProjectsUrl } from '~/utils/postgrestUrl'
+import {ssrProjectsUrl} from '~/utils/postgrestUrl'
 
 type KeywordBoxProps = {
     label: string
 }
 
-export default function KeywordBox({ label }: KeywordBoxProps) {
-    const url = ssrProjectsUrl({ keywords: [label] })
+export default function KeywordBox({label}: KeywordBoxProps) {
+    const url = ssrProjectsUrl({keywords: [label]})
     return (
         <div className="bg-secondary text-primary-content p-2 text-center rounded-md">
             <div className="text-lg">

--- a/frontend/components/home/imperial/KeywordBox.tsx
+++ b/frontend/components/home/imperial/KeywordBox.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+
+import { ssrProjectsUrl } from '~/utils/postgrestUrl'
+
+type KeywordBoxProps = {
+    label: string
+}
+
+export default function KeywordBox({ label }: KeywordBoxProps) {
+    const url = ssrProjectsUrl({ keywords: [label] })
+    return (
+        <div className="bg-secondary text-primary-content p-2 text-center rounded-md">
+            <div className="text-lg">
+                <Link href={url}>
+                    {label}
+                </Link>
+            </div>
+        </div>
+    )
+}

--- a/frontend/components/home/imperial/Keywords.tsx
+++ b/frontend/components/home/imperial/Keywords.tsx
@@ -1,11 +1,15 @@
 import KeywordBox from './KeywordBox'
 
 type KeywordsProps = {
-    keywords: object
+    keywords: Array<KeywordsObject>
+}
+
+type KeywordsObject = {
+    value: string
 }
 
 export default function Keywords({keywords}: KeywordsProps) {
-    const keywordButtons = keywords.map((keyword: object, index: number) => {
+    const keywordButtons = keywords.map((keyword: KeywordsObject, index: number) => {
         return <KeywordBox key={index} label={keyword.value} />
     })
     return (

--- a/frontend/components/home/imperial/Keywords.tsx
+++ b/frontend/components/home/imperial/Keywords.tsx
@@ -1,17 +1,21 @@
 import KeywordBox from './KeywordBox'
 
 type KeywordsProps = {
-    keywords: string
+    keywords: object
 }
 
-export default function Keywords({ keywords }: KeywordsProps) {
-    const keywordArray = JSON.parse(keywords)
-    const keywordButtons = keywordArray.map((keyword, index) => {
+export default function Keywords({keywords}: KeywordsProps) {
+    const keywordButtons = keywords.map((keyword: object, index: number) => {
         return <KeywordBox key={index} label={keyword.value} />
     })
     return (
-        <div className="max-w-screen-xl mx-auto flex flex-wrap gap-10 md:gap-3 p-5 md:p-10 ">
-            {keywordButtons}
+        <div className="max-w-screen-xl mx-auto">
+            <div className="text-2xl ml-10 mt-14">
+                Popular Keywords
+            </div>
+            <div className="flex flex-wrap gap-10 md:gap-3 p-5 md:p-10 ">
+                {keywordButtons}
+            </div>
         </div>
     )
 }

--- a/frontend/components/home/imperial/Keywords.tsx
+++ b/frontend/components/home/imperial/Keywords.tsx
@@ -1,0 +1,17 @@
+import KeywordBox from './KeywordBox'
+
+type KeywordsProps = {
+    keywords: string
+}
+
+export default function Keywords({ keywords }: KeywordsProps) {
+    const keywordArray = JSON.parse(keywords)
+    const keywordButtons = keywordArray.map((keyword, index) => {
+        return <KeywordBox key={index} label={keyword.value} />
+    })
+    return (
+        <div className="max-w-screen-xl mx-auto flex flex-wrap gap-10 md:gap-3 p-5 md:p-10 ">
+            {keywordButtons}
+        </div>
+    )
+}

--- a/frontend/components/home/imperial/MainContentImperialCollege.tsx
+++ b/frontend/components/home/imperial/MainContentImperialCollege.tsx
@@ -6,17 +6,17 @@
 import Image from 'next/legacy/image'
 import Link from 'next/link'
 
-import { HomeProps } from 'pages'
+import {HomeProps} from 'pages'
 import CounterBox from './CounterBox'
 import Keywords from './Keywords'
-import { useSession } from '~/auth'
+import {useSession} from '~/auth'
 import useImperialData from './useImperialData'
 import ContentLoader from '~/components/layout/ContentLoader'
 import MainContent from '~/components/layout/MainContent'
 
-export default function MainContentImperialCollege({ counts }: HomeProps) {
-  const { token } = useSession()
-  const { loading, keywords } = useImperialData(token)
+export default function MainContentImperialCollege({counts}: HomeProps) {
+  const {token} = useSession()
+  const {loading, keywords} = useImperialData(token)
 
   return (
     <MainContent>
@@ -70,7 +70,7 @@ export default function MainContentImperialCollege({ counts }: HomeProps) {
           <ContentLoader />
           :
           <div className="mb-12">
-            <Keywords keywords={JSON.stringify(keywords, null, ' ')} />
+            <Keywords keywords={keywords} />
           </div>
       }
 

--- a/frontend/components/home/imperial/MainContentImperialCollege.tsx
+++ b/frontend/components/home/imperial/MainContentImperialCollege.tsx
@@ -6,16 +6,21 @@
 import Image from 'next/legacy/image'
 import Link from 'next/link'
 
-import {HomeProps} from 'pages'
+import { HomeProps } from 'pages'
 import CounterBox from './CounterBox'
-import {useSession} from '~/auth'
+import Keywords from './Keywords'
+import { useSession } from '~/auth'
 import useImperialData from './useImperialData'
 import ContentLoader from '~/components/layout/ContentLoader'
 import MainContent from '~/components/layout/MainContent'
 
-export default function MainContentImperialCollege({counts}: HomeProps) {
-  const {token} = useSession()
-  const {loading, keywords} = useImperialData(token)
+export default function MainContentImperialCollege({ counts }: HomeProps) {
+  const { token } = useSession()
+  const { loading, keywords } = useImperialData(token)
+  console.log(keywords)
+  console.log(typeof keywords)
+  console.log(JSON.stringify(keywords, null, ' '))
+  console.log(typeof JSON.stringify(keywords, null, ' '))
 
   return (
     <MainContent>
@@ -67,11 +72,9 @@ export default function MainContentImperialCollege({counts}: HomeProps) {
       {
         loading ?
           <ContentLoader />
-        :
+          :
           <div className="mb-12">
-            <pre>
-              {JSON.stringify(keywords,null,' ')}
-            </pre>
+            <Keywords keywords={JSON.stringify(keywords, null, ' ')} />
           </div>
       }
 

--- a/frontend/components/home/imperial/MainContentImperialCollege.tsx
+++ b/frontend/components/home/imperial/MainContentImperialCollege.tsx
@@ -17,10 +17,6 @@ import MainContent from '~/components/layout/MainContent'
 export default function MainContentImperialCollege({ counts }: HomeProps) {
   const { token } = useSession()
   const { loading, keywords } = useImperialData(token)
-  console.log(keywords)
-  console.log(typeof keywords)
-  console.log(JSON.stringify(keywords, null, ' '))
-  console.log(typeof JSON.stringify(keywords, null, ' '))
 
   return (
     <MainContent>


### PR DESCRIPTION
Added keyword buttons on the front page that link to the search function. Opened in draft in case there are extra repo hygiene steps I've missed out. Closes https://github.com/ImperialCollegeLondon/RSD-as-a-service/issues/17.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
